### PR TITLE
Port setup.py to GTK+ 3 and verify upstream sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 
-from sugar.activity import bundlebuilder
+from sugar3.activity import bundlebuilder
 
 bundlebuilder.start()
 


### PR DESCRIPTION
* "``from sugar.activity``" did use the old GTK+ 2 toolkit, change to use the new GTK+ 3 toolkit, (the rest of the source code uses GTK+ 3 toolkit already),

* verified Twisted source in this repository matches tag `twisted-16.6.0` from upstream project https://github.com/twisted/twisted.git

* verified Zope source in this repository matches tag `4.3.2` from upstream project https://github.com/zopefoundation/zope.interface.git